### PR TITLE
Changed the name of the topmost collection to "IIIF Manifest"

### DIFF
--- a/modules/importer.py
+++ b/modules/importer.py
@@ -344,7 +344,7 @@ class ImportIIIF3DManifest(Operator, ImportHelper):
         """Process the manifest data and import the model"""
 
         # Store manifest metadata on the main scene collection
-        main_collection = self.create_or_get_collection("IIIF Scene")
+        main_collection = self.create_or_get_collection("IIIF Manifest")
         metadata = IIIFMetadata(main_collection)
         metadata.store_manifest(manifest_data)
 


### PR DESCRIPTION
The topmost collection had been name "IIIF Scene", the name IIIF Manifest seems more appropriates, since it contains (at least one) Collection for a Scene in the manifest. The behavior when a manifest contains multiple scene has not been tested
<img width="1608" alt="Screenshot 2025-03-19 at 4 27 49 PM" src="https://github.com/user-attachments/assets/c37fd21d-315c-4c52-858d-59a23eb68d37" />
