### PR TITLE
Fix case of IIIF "type" values

### DIFF
--- a/modules/exporter.py
+++ b/modules/exporter.py
@@ -47,7 +47,7 @@ class ExportIIIF3DManifest(Operator, ExportHelper):
         """
         # sanity check
         iiif_type = collection.get("iiif_type", None)
-        if  iiif_type == "scene":
+        if  iiif_type.lower() == "Scene".lower():
             scene_id = collection.get("iiif_id",None)
             if not scene_id:
                 logger.warning("invalid id for exporting scene %r" % (scene_id,))
@@ -79,7 +79,7 @@ class ExportIIIF3DManifest(Operator, ExportHelper):
             # Update existing annotation page or add new one
             found = False
             for i, item in enumerate(scene_data['items']):
-                if item.get('type') == 'AnnotationPage':
+                if item.get('type').lower() == 'AnnotationPage'.lower():
                     scene_data['items'][i] = annotation_page
                     found = True
                     break
@@ -309,7 +309,7 @@ class ExportIIIF3DManifest(Operator, ExportHelper):
 
         # Process scenes
         for collection in bpy.data.collections:            
-            if collection.get("iiif_type",None) == "scene":
+            if collection.get("iiif_type",None).lower() == "Scene".lower():
                 scene_data = self.get_scene_data(context, collection)
                 if scene_data:
                     manifest_data["items"].append(scene_data)

--- a/modules/metadata.py
+++ b/modules/metadata.py
@@ -35,7 +35,7 @@ class IIIFMetadata:
         """Store complete manifest data"""
         self.obj[self._get_key("manifest")] = json.dumps(data)
         self.obj[self._get_key("import_date")] = datetime.now().isoformat()
-        self.obj[self._get_key("type")] = "manifest"
+        self.obj[self._get_key("type")] = "Manifest"
         self.obj[self._get_key("id")] = data.get("id","not_supplied")
 
     def store_annotation(self, data: Dict) -> None:
@@ -51,7 +51,7 @@ class IIIFMetadata:
     def store_scene(self, data: Dict) -> None:
         """Store scene data"""
         self.obj[self._get_key("scene")] = json.dumps(data)
-        self.obj[self._get_key("type")] = "scene"
+        self.obj[self._get_key("type")] = "Scene"
         if "id" in data:
             self.obj[self._get_key("id")] = data.get("id","not_supplied")
 


### PR DESCRIPTION
Modified code in importer so that imported manifests are assigned the value "Manifest" as the IIIF type and and imported (IIIF) scene resources are assigned "Scene" . Code before this change used lower-case values in some instances.

Modified the exporter code to use case-insensitive comparison of IIIF types.