### PR TITLE
Update tests for import

### DIFF
--- a/run_blender_with_plugin.py
+++ b/run_blender_with_plugin.py
@@ -20,7 +20,6 @@ if len(sys.argv) < 4:
 
 # Get the input and output manifest file paths from the command line arguments
 input_manifest = sys.argv[sys.argv.index("--") + 1]
-output_manifest = input_manifest.replace(".json", "_export.json")
 
 context = bpy.context
 if context is None:
@@ -68,97 +67,10 @@ if ext_name not in context.preferences.addons:
     sys.exit(1)
 
 
-def safe_delete(file_path):
-    try:
-        # Check if file exists before attempting deletion
-        if os.path.exists(file_path):
-            os.remove(file_path)
-            print(f"File {file_path} has been deleted successfully")
-        else:
-            print(f"File {file_path} does not exist")
-    except Exception as e:
-        print(f"Error occurred while deleting file: {e}")
-
-
-RED: Callable[[str], str] = lambda text: f"\u001b[31m{text}\033\u001b[0m"
-GREEN: Callable[[str], str] = lambda text: f"\u001b[32m{text}\033\u001b[0m"
-
-
-def get_edits_string(old: str, new: str) -> Tuple[str, bool]:
-    result = ""
-
-    lines = difflib.ndiff(old.splitlines(keepends=True), new.splitlines(keepends=True))
-
-    has_changes = False
-
-    for line in lines:
-        line = line.rstrip()
-        if line.startswith("+"):
-            has_changes = True
-            result += GREEN(line) + "\n"
-        elif line.startswith("-"):
-            has_changes = True
-            result += RED(line) + "\n"
-        elif line.startswith("?"):
-            continue
-        else:
-            result += line + "\n"
-
-    return (result, has_changes)
-
-
-def get_json_diff(file1_path: str, file2_path: str) -> Tuple[str, bool]:
-    with open(file1_path) as f1:
-        json1 = json.load(f1)
-    with open(file2_path) as f2:
-        json2 = json.load(f2)
-    return get_edits_string(
-        json.dumps(json1, indent=2, sort_keys=True),
-        json.dumps(json2, indent=2, sort_keys=True),
-    )
-
-
-def get_indent(level):
-    return "  " * level
-
-
-def print_object_hierarchy(obj, level):
-    indent = get_indent(level)
-    print(f"{indent}- {obj.name} ({obj.type})")
-
-    for child in obj.children:
-        print_object_hierarchy(child, level + 1)
-
-
-def print_collection_hierarchy(collection, level=0):
-    indent = get_indent(level)
-    print(f"{indent}{collection.name} (Collection):")
-
-    for obj in collection.objects:
-        if not obj.parent:
-            print_object_hierarchy(obj, level + 1)
-
-    for child_col in collection.children:
-        print_collection_hierarchy(child_col, level + 1)
-
-
-bpy.ops.import_scene.iiif_manifest(filepath=input_manifest)
-
-print("\n\nPrinting scene hierarchy:")
-print_collection_hierarchy(bpy.context.scene.collection)
-print("\n\n")
-
-bpy.ops.export_scene.iiif_manifest(filepath=output_manifest)
-
-differences, has_changes = get_json_diff(input_manifest, output_manifest)
-
-# Delete output manifest
-safe_delete(output_manifest)
-
-if has_changes:
-    print("Imported manifest differs from exported manifest:")
-    print(differences)
+try:
+    bpy.ops.import_scene.iiif_manifest(filepath=input_manifest)
+except Exception as exc:
+    print(str(exc))
     sys.exit(1)
 else:
-    print("Imported manifest equals exported manifest")
     sys.exit(0)

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -20,12 +20,8 @@ run_test() {
     fi
 }
 
-# change made 15 Apr 2025 by VJM, only run the test on 
-# the single 0101_model_origin.json file rather than all files
-# found by glob via 
-# for manifest in tests/iiif_manifests/*.json; do
-for manifest in tests/iiif_manifests/0101_model_origin.json; do
-    echo "ℹ️  Testing manifest: $manifest"
+for manifest in tests/iiif_manifests/*.json; do
+    echo "ℹ️  Testing import of manifest: $manifest"
     if ! run_test "blender --background --python run_blender_with_plugin.py -- '$manifest'"; then
         ((FAILED_TESTS++))
     fi


### PR DESCRIPTION
The run_blender_with_plugin python script has been simplified and reduced in scope, so that when it runs in the Blender python environment with an input file path to a manifest.json file, all it does is:
1. Verify that the plugin is available and enabled
2. Import the manifest as a Blender scene

In the testing environment, success of import is defined as import without a Python exception being raised.

At this commit only two manifests are tested, but additional examples can just be copied into the tests/iiif_manifests folder