### PR TITLE
Updates to Blender plugin based on draft Pres 4 and validator

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -52,9 +52,10 @@ class OUTLINER_MT_edit_manifest_anno_page(Menu):
     
     def draw(self,context):
         layout = self.layout
-        layout.operator(ImportLocalModel.bl_idname, text="Add Local Model")
-        layout.operator(ImportNetworkModel.bl_idname, text="Add Network Model")
-        layout.operator(NewCamera.bl_idname, text="Add Camera")
+        if layout is not None:
+            layout.operator(ImportLocalModel.bl_idname, text="Add Local Model")
+            layout.operator(ImportNetworkModel.bl_idname, text="Add Network Model")
+            layout.operator(NewCamera.bl_idname, text="Add Camera")
         
 
 

--- a/modules/Configure3DViewport.py
+++ b/modules/Configure3DViewport.py
@@ -7,12 +7,13 @@ logger = logging.getLogger("iiif.configure_viewport")
 
 
 def findSpaceView3D(c:Context):
-    for window in c.window_manager.windows:
-         for area in window.screen.areas:
-            if area.type == 'VIEW_3D':
-                for space in area.spaces:
-                    if space.type == 'VIEW_3D':
-                        yield space # This is your SpaceView3D instance
+    if c.window_manager is not None:
+        for window in c.window_manager.windows:
+             for area in window.screen.areas:
+                if area.type == 'VIEW_3D':
+                    for space in area.spaces:
+                        if space.type == 'VIEW_3D':
+                            yield space # This is your SpaceView3D instance
 
 class Configure3DViewport(Operator):
     """

--- a/modules/ExportManifest.py
+++ b/modules/ExportManifest.py
@@ -216,12 +216,6 @@ class ExportManifest(Operator, ExportHelper):
 
     def resource_data_for_camera(self, blender_obj:bpy.types.Object) -> dict:
         resource_data = self.get_base_data(blender_obj)
-        
-        # July 3 2025 : We do not want to output an id for cameras that look like URLS
-        # because some viewers are trying to download these that are body resources
-        # of "painting" motivation annotations
-        if "id" in resource_data:
-            del resource_data["id"]
 
         foValue : float = float(blender_obj.data.angle_y) # pyright: ignore[reportAttributeAccessIssue, reportOptionalMemberAccess]
         resource_data["fieldOfView"] =  math.degrees(foValue) 

--- a/modules/ExportManifest.py
+++ b/modules/ExportManifest.py
@@ -6,6 +6,7 @@ from bpy.props import StringProperty
 from bpy.types import Context, Operator, Object
 from bpy_extras.io_utils import ExportHelper
 from mathutils import Vector, Quaternion
+from .editing import generate_id
 
 from .utils.color import rgba_to_hex
 
@@ -155,6 +156,7 @@ class ExportManifest(Operator, ExportHelper):
         if (len(transforms) > 0):
             specific_resource = {
                 "type" : "SpecificResource",
+                "id"   : generate_id("SpecificResource"),
                 "transform" : [
                     t.to_iiif_dict() for t in transforms
                 ],
@@ -178,12 +180,14 @@ class ExportManifest(Operator, ExportHelper):
             def build_selector(tt:Translation) -> dict:
                 tmp = tt.to_iiif_dict()
                 tmp["type"]="PointSelector"
+                tmp["id"]  = generate_id("PointSelector")
                 return tmp
                 
             selector = build_selector( transforms[-1] )
             
             return {
                 "type": "SpecificResource",
+                "id"   : generate_id("SpecificResource"),
                 "selector" : selector,
                 "source"   : scene_resource
             }

--- a/modules/ImportLocalModel.py
+++ b/modules/ImportLocalModel.py
@@ -85,7 +85,8 @@ class ImportLocalModel(Operator,  ImportHelper):
         configure_model(new_model, model_data,placement)
         
         annotation_collection=new_annotation()
-        context.collection.children.link(annotation_collection) 
+        if context.collection is not None:
+            context.collection.children.link(annotation_collection) 
 
         
         LOOP_GUARD_MAX=8

--- a/modules/ImportManifest.py
+++ b/modules/ImportManifest.py
@@ -82,7 +82,8 @@ class ImportManifest(Operator, ImportHelper):
 
         # Store manifest metadata on the main scene collection
         main_collection = new_manifest( manifest_data )
-        move_collection_into_parent( main_collection, self.context.scene.collection)
+        if self.context.scene is not None:
+            move_collection_into_parent( main_collection, self.context.scene.collection)
 
         if "items" in manifest_data:
             for item in manifest_data["items"][:]: # iterate over a copy

--- a/modules/ImportNetworkModel.py
+++ b/modules/ImportNetworkModel.py
@@ -55,8 +55,9 @@ class ImportNetworkModel(Operator):
     def invoke(self, context, event):
         logger.info("ImportRemoteModel.invoke entered")
         self.model_url=""
-        rv = context.window_manager.invoke_props_dialog(self, width=640)
-        logger.info("return from invoke_props_dialog %r : %r" % (rv, self.model_url) )
+        if context.window_manager is not None:
+            rv = context.window_manager.invoke_props_dialog(self, width=640)
+            logger.info("return from invoke_props_dialog %r : %r" % (rv, self.model_url) )
         return rv
 
 
@@ -87,7 +88,8 @@ class ImportNetworkModel(Operator):
         configure_model(new_model, model_data,placement)
         
         annotation_collection=new_annotation()
-        context.collection.children.link(annotation_collection) 
+        if context.collection is not None:
+            context.collection.children.link(annotation_collection) 
 
         
         LOOP_GUARD_MAX=8

--- a/modules/LoadLocalModel.py
+++ b/modules/LoadLocalModel.py
@@ -84,6 +84,7 @@ class LoadLocalModel(Operator):
         # so that an existing importer Operator can be wrapped at run-time
         # with a wrapper function that supplied other import arguments
 
+        logger.info(f"LoadLocalModel.execute self.mimetype: {self.mimetype}")
         try:
             handler, handler_name = handler_for_mimetype(self.mimetype)
         except KeyError:
@@ -153,7 +154,7 @@ def wrapped_gltf(*args, **keyw) -> Set[str]:
 
 def handler_for_mimetype( mimetype:str) -> Tuple[Callable[..., Set[str]] , str] :
     """
-    return 2-tuple (func, label)
+    return 2-tuple (func, label), or raises KeyError
     function is the callable, may be Blender defined operator call such as 
     bpy.ops.import_scene.gltf 
     label a string used only for logging messages
@@ -166,8 +167,7 @@ def handler_for_mimetype( mimetype:str) -> Tuple[Callable[..., Set[str]] , str] 
         
     mimetype_importer_dict = {
         "model/gltf-binary" :           GLTF_IMPORTER,
-        "model/gltf+json"   :           GLTF_IMPORTER,
-        "application/octet-stream"  :   GLTF_IMPORTER   
+        "model/gltf+json"   :           GLTF_IMPORTER  
     }
     
     return mimetype_importer_dict[mimetype]

--- a/modules/LoadLocalModel.py
+++ b/modules/LoadLocalModel.py
@@ -148,7 +148,11 @@ def wrapped_gltf(*args, **keyw) -> Set[str]:
     saved_debug_value = bpy.app.debug_value
     bpy.app.debug_value = 1 # this is equivalent to logging.WARN
     try:
-        return bpy.ops.import_scene.gltf(*args, **keyw)
+        import_gltf_returnset = bpy.ops.import_scene.gltf(*args, **keyw)
+        if import_gltf_returnset is None:
+            logger.error("call to bpy.ops.import_scene.gltf returned None")
+            return {"CANCELLED"}
+        return import_gltf_returnset
     finally:
         bpy.app.debug_value = saved_debug_value
 

--- a/modules/LoadNetworkModel.py
+++ b/modules/LoadNetworkModel.py
@@ -9,6 +9,9 @@ import bpy
 from bpy.props import StringProperty
 from bpy.types import Context, Operator
 
+from .LoadLocalModel import handler_for_mimetype
+from .editing.models import  mimetype_from_extension
+
 import logging
 logger = logging.getLogger("iiif.import_network_model")
 
@@ -84,8 +87,26 @@ class LoadNetworkModel(Operator):
                 # URL data downloaded to local_filepath and 
                 # http_mimetype set to the Content-Type (or to "")
     
+            # logic for figuring out a mimetype to decode the resource as a 3D asset
+            def choose_mimetype():
+                for mime_choice in (http_mimetype, self.mimetype):
+                    try:
+                        handler_for_mimetype( mime_choice)
+                    except KeyError:
+                        continue
+                    return mime_choice
+                
+                # if neither http_mimetype, self.mimetype are supported,
+                # try to get somethinf from the extension on the model_basename
+                try:
+                    return mimetype_from_extension( model_basename )
+                except Exception:
+                    pass
                     
-            mimetype = self.mimetype or http_mimetype
+                # if all else fails, return mimetype for glb as the default:
+                return "model/gltf-binary"
+                         
+            mimetype = choose_mimetype()
             
             # call the ImportLocalModel Operator to import the contents
             # of the local_filepath file into Blender as a Blender Object

--- a/modules/NewCamera.py
+++ b/modules/NewCamera.py
@@ -24,7 +24,8 @@ class NewCamera(Operator):
     def execute(self, context):
         
         annotation_page_collection = context.collection
-        if not annotation_page_collection.get("iiif_type","") == "AnnotationPage":
+        if  annotation_page_collection is None or \
+            annotation_page_collection.get("iiif_type","") != "AnnotationPage":           
             logger.warning("invalid context.collection: %r" % (annotation_page_collection,))
             return {"CANCELLED"}
 

--- a/modules/NewCamera.py
+++ b/modules/NewCamera.py
@@ -5,6 +5,7 @@ from mathutils import Vector, Quaternion
 from .editing.collections import new_annotation
 from .editing.transforms import Translation, Rotation, transformsToPlacements
 from .editing.cameras import configure_camera
+from .editing import generate_id
 #from .utils.coordinates import Coordinates
 from .utils.blender_setup import setup_camera
 
@@ -43,7 +44,8 @@ class NewCamera(Operator):
             setup_camera(new_camera)
             
             resource_data = {
-                "type" : "PerspectiveCamera"
+                "type" : "PerspectiveCamera",
+                "id"   : generate_id("PerspectiveCamera")
             }
 
             # the placement of the camera is intended to be out 

--- a/modules/NewManifest.py
+++ b/modules/NewManifest.py
@@ -30,7 +30,8 @@ class NewManifest(Operator):
         logger.info("call Configure3DViewport")
         res = bpy.ops.iiif.configure_viewport() # pyright: ignore[reportAttributeAccessIssue]
         logger.info("result Configure3DViewport: %s" % res)
-        bpy.context.scene.collection.children.link(manifest)
+        if bpy.context.scene is not None and bpy.context.scene.collection is not None:
+            bpy.context.scene.collection.children.link(manifest)
         
         iiif_scene = new_scene()
         manifest.children.link(iiif_scene)

--- a/modules/SceneBackground.py
+++ b/modules/SceneBackground.py
@@ -47,9 +47,11 @@ class IIIBackgroundPanel(Panel):
         Panel unless the active collection  (instance of Collection)
         is one that organizes a IIIF Scene resource
         """
-        if context.collection.get("iiif_type","") == "Scene":
+        if  context.collection is not None and \
+            context.collection.get("iiif_type","") == "Scene":
             return True
-        return None
+        else:
+            return None
         
     def draw(self, context):
         if not context:

--- a/modules/custom_props.py
+++ b/modules/custom_props.py
@@ -12,13 +12,13 @@ class AddIIIF3DObjProperties(Operator):
 
     def execute(self, context: Context) -> Set[str]:
         try:
-            obj = context.view_layer.objects.active
-            if obj is not None:
-                if "iiif_annotation_id" not in obj:
-                    obj["iiif_annotation_id"] = obj.name
-                if "iiif_source_url" not in obj:
-                    obj["iiif_source_url"] = "https://example.org/iiif/3d/manifest.json"
-
+            if context.view_layer is not None:
+                obj = context.view_layer.objects.active
+                if obj is not None:
+                    if "iiif_annotation_id" not in obj:
+                        obj["iiif_annotation_id"] = obj.name
+                    if "iiif_source_url" not in obj:
+                        obj["iiif_source_url"] = "https://example.org/iiif/3d/manifest.json"
             return {"FINISHED"}
         except Exception as e:
             import traceback
@@ -36,10 +36,11 @@ class AddIIIF3DCollProperties(Operator):
     def execute(self, context: Context) -> Set[str]:
         try:
             coll = context.collection
-            if "iiif_annotation_id" not in coll:
-                coll["iiif_annotation_id"] = coll.name
-            if "iiif_source_url" not in coll:
-                coll["iiif_source_url"] = "https://example.org/iiif/3d/manifest.json"
+            if coll is not None:
+                if "iiif_annotation_id" not in coll:
+                    coll["iiif_annotation_id"] = coll.name
+                if "iiif_source_url" not in coll:
+                    coll["iiif_source_url"] = "https://example.org/iiif/3d/manifest.json"
 
             return {"FINISHED"}
         except Exception as e:

--- a/modules/editing/__init__.py
+++ b/modules/editing/__init__.py
@@ -1,14 +1,18 @@
 from typing import Optional
 import bpy
+import uuid
+    
+# module level constant
+RANDOM_TEXT  = str(uuid.uuid4())[:8]
 
 def generate_id(resource_type="Manifest") -> str:
     """
-    generates an identifier following the convention for a 
-    'blank node identifier' (see https://www.w3.org/TR/rdf11-concepts/#dfn-blank-node-identifier)
-    as references in JSON-LD 1.1 document (see https://www.w3.org/TR/json-ld11/ )
+    
     """
     import re
-    prefix = "_:%s/" % resource_type.lower()
+    
+    
+    prefix = "https://%s/%s/" % ( RANDOM_TEXT, resource_type.lower())
     re_pattern= re.compile( prefix+r"([0-9]+)\s*$" )
     imax=0
     for obj_or_col in ( list(bpy.data.objects) + list(bpy.data.collections) ):

--- a/modules/editing/cameras.py
+++ b/modules/editing/cameras.py
@@ -8,6 +8,7 @@ from typing import List
 from . import generate_id
 from ..utils.json_patterns import force_as_singleton
 from ..editing.transforms import Transform, Rotation, Placement, transformsToPlacements
+from . import generate_id
 
 import logging
 logger = logging.getLogger("iiif.cameras")
@@ -48,6 +49,6 @@ def configure_camera(   new_camera : Object,
 
 def _initial_data() -> dict :
     return {
-        "id" : None,
+        "id" : generate_id("PerspectiveCamera"),
         "type": "PerspectiveCamera"
     }

--- a/modules/editing/cameras.py
+++ b/modules/editing/cameras.py
@@ -8,18 +8,16 @@ from typing import List
 from . import generate_id
 from ..utils.json_patterns import force_as_singleton
 from ..editing.transforms import Transform, Rotation, Placement, transformsToPlacements
-from . import generate_id
 
 import logging
 logger = logging.getLogger("iiif.cameras")
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
 
 def configure_camera(   new_camera : Object,                                                 
                         resource_data : dict,
                         placement : Placement ) -> None:
     if len(resource_data) == 0:
         resource_data = _initial_data()
-        resource_data["id"]=generate_id(resource_data["type"])
         
     if "type" not in resource_data:
         logger.warn("camera type not specified")
@@ -32,6 +30,7 @@ def configure_camera(   new_camera : Object,
         
     
     new_camera["iiif_type"] = resource_data["type"]
+    new_camera["iiif_id"]   = resource_data["id"]
     new_camera["iiif_json"] = json.dumps(resource_data)
     
     new_camera.location = placement.translation.data
@@ -48,7 +47,8 @@ def configure_camera(   new_camera : Object,
 
 
 def _initial_data() -> dict :
-    return {
+    retVal = {
         "id" : generate_id("PerspectiveCamera"),
         "type": "PerspectiveCamera"
     }
+    return retVal

--- a/modules/editing/models.py
+++ b/modules/editing/models.py
@@ -63,6 +63,7 @@ def configure_model(    new_model : Object,
         if "format" in resource_data and resource_data["format"] != mimetype:
             message=f'resource format ${resource_data["format"]} does not match ${mimetype}'
             logger.warn(message)
+        resource_data["format"] = mimetype
     new_model["iiif_type"] = "Model"
     new_model["iiif_json"] = json.dumps(resource_data)
 

--- a/modules/editing/transforms.py
+++ b/modules/editing/transforms.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 from  typing import  Any, Dict, List,  Callable, Generator, Iterable
 from mathutils import Vector, Quaternion, Euler
 from math import radians, degrees,   pi
+from . import generate_id
 from bpy.types import Object
+
 
 # Dev Note: 9 Aug 2025
 # this import of annotations will allow the type hint system
@@ -88,7 +90,8 @@ class Translation(Transform):
         iv = [self.data.x, self.data.z, -self.data.y]
         
         # express as dictionary
-        retVal : Dict[str,Any] = {"type": TRANSLATE_TRANSFORM}
+        retVal : Dict[str,Any] = {  "type": TRANSLATE_TRANSFORM,
+                                    "id": generate_id(TRANSLATE_TRANSFORM) }
         for label, v in zip( XYZ, iv):
             if v != 0.0:
                 retVal[label] = v
@@ -147,7 +150,8 @@ class Rotation(Transform):
         iv = [degrees(r) for r in [euler.x, euler.z, -euler.y]]
         
         # express as dictionary
-        retVal : Dict[str,Any] = {"type": ROTATE_TRANSFORM}
+        retVal : Dict[str,Any] = {"type": ROTATE_TRANSFORM,
+                                    "id": generate_id(ROTATE_TRANSFORM) }
         for label, v in zip( XYZ, iv):
             if v != 0.0:
                 retVal[label] = v
@@ -259,7 +263,8 @@ class Scaling(Transform):
         iv = [self.data.x, self.data.z,self.data.y]
         
         # express as dictionary
-        retVal : Dict[str,Any] = {"type": SCALE_TRANSFORM}
+        retVal : Dict[str,Any] = {  "type": SCALE_TRANSFORM,
+                                    "id": generate_id(SCALE_TRANSFORM) }
         for label, v in zip( XYZ, iv):
             if v != 1.0:
                 retVal[label] = v

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -40,7 +40,7 @@ class IIIFManifestPanel(Panel):
 
         layout = self.layout
         scene = context.scene
-
-        layout.prop(scene, "iiif_manifest_id")
-        layout.prop(scene, "iiif_manifest_label")
-        layout.prop(scene, "iiif_manifest_summary")
+        if layout is not None and scene is not None:
+            layout.prop(scene, "iiif_manifest_id")
+            layout.prop(scene, "iiif_manifest_label")
+            layout.prop(scene, "iiif_manifest_summary")

--- a/modules/utils/coordinates.py
+++ b/modules/utils/coordinates.py
@@ -116,7 +116,7 @@ class Coordinates:
         
 
     @staticmethod
-    def coerce_to_euler( rotation : Euler | Quaternion , order:str ) -> Euler:
+    def coerce_to_euler( rotation : Euler | Quaternion , order ) -> Euler:
         if isinstance(rotation, Euler) and rotation.order != order :
             return rotation.to_quaternion().to_euler(order)
         elif isinstance(rotation, Quaternion):

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -3,6 +3,6 @@
   "venv": "venv",
   "typeCheckingMode": "basic",
   "reportMissingImports": true,
-  "pythonVersion": "3.12",
+  "pythonVersion": "3.11",
   "extraPaths": ["./venv/lib/python3.12/site-packages"]
 }

--- a/run_blender_with_plugin.py
+++ b/run_blender_with_plugin.py
@@ -44,12 +44,13 @@ def get_extension_id():
 needle = get_extension_id()
 logger.debug("needle is %s" % (needle,))
 ext_name = None
-logger.debug("addons.keys is %s" % ( "\n".join( context.preferences.addons.keys()),))
-for key in context.preferences.addons.keys():
-    if needle in key:
-        ext_name = key
-        logger.debug("ext_name is %s" % (ext_name,))
-        break
+
+if context.preferences is not None:
+    for key in context.preferences.addons.keys():
+        if needle in key:
+            ext_name = key
+            logger.debug("ext_name is %s" % (ext_name,))
+            break
 
 if not ext_name:
     print("Failed to find the plugin")
@@ -59,7 +60,8 @@ bpy.ops.preferences.addon_enable(module=ext_name)
 
 
 
-if ext_name not in context.preferences.addons:
+if  context.preferences is None or \
+    ext_name not in context.preferences.addons:
     print("Failed to load the plugin")
     sys.exit(1)
 


### PR DESCRIPTION
Modifies the manifest export function to comply with new requirements on manifests in the Presentation 4 draft spec, and flagged as errors by the validator

-- all resources must have a URI, and that URI must  start with an http or https schema fragment, although it does not have to be dereferenceable

-- no empty format properties allowed.

These changes do not deliver new capabilities. I propose it be released as a patch upgrade, version 1.0.1